### PR TITLE
Change log visibility changes

### DIFF
--- a/Change Log.md
+++ b/Change Log.md
@@ -1,0 +1,52 @@
+# Object Explorer Change Log
+
+### 2022-11-23, Version 3.3.6
+
+* New: Double click now works on any column in the grid to edit property values.  
+* New: Right-click on grid row brings up context menu to edit property (same as double-click) or to toggle whether the property is a favorite
+* New: Checkbox for whether favorites are highlighted (with yellow highlighter)
+
+### 2022-05-22, Version 3.3.3
+
+* Add a TRY in TreeContainer.Init so no error if _Screen.oISXOptions.oKeyWordList doesn't exist
+
+### 2022-04-04
+
+* Updated the download zip file so it works with Thor Check for Updates.
+
+### 2022-04-03
+
+* Fixes a bug with an object based on Control in a running form and updates the displayed version number.
+
+### 2022-04-02
+
+* Fixes a bug with null nodes, such as with an object based on Empty or Control.
+
+### 2022-03-04
+
+* Automatically closes when the object being explored is released, and no longer prevents the object from being released
+
+### 2022-03-03
+
+* Changed hard-coded "explorer.vcx" in NEWOBJECT() statements to This.ClassLibrary so pathing isn't an issue.
+
+* Set AllowOutput to .F. in forms.
+
+* Ensure the explorer form is visible by being positioned within _screen or the active form, depending on the setting of ShowWindow.
+
+* Added support for Thor Check For Updates.
+
+### 2022-02-28
+
+* Initial release: Jim and Matt's original version plus the following changes by Doug Hennig:
+
+    * TreeContainer.NewNode: accept toParentNode and use the appropriate version of Nodes.Add if it's an object. This change (and the next one) prevents cashing for some objects (the TreeView was getting cranky when changing the Parent property of a node).
+
+    * TreeContainer.LoadObject and LoadOtherObject: call NewNode rather than using their own Nodes.Add calls.
+
+    * TreeContainer.NavigateToObject: specifically set loNode.Expanded to .T. because calling Expand doesn't necessary do that, also call loNode.EnsureVisible to ensure the TreeView is scrolled to the node. This fixes an issue with not automatically selecting the correct object in the TreeView at startup: the form was selected rather than the object, although the grid showed the properties for the correct object.
+
+    * TreeContainer.InputBox: use InputBox_ShowWindow1 if the form is in a top-level form, not if it's modal. This change (and the next one) allows Object Explorer to be used in apps with _screen.Visible set to .F. and using top-level forms.
+
+    * InputBox_ShowWindow1: set Desktop to .T. This doesn't affect apps with _screen.Visible =  .T. but does allow it to work when it's .F.
+

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 By Jim Nelson and Matt Slay
 
+[Change Log](Change%20Log.md)
+
 *Provides an explorer form to view members of the specified object.*
 
 ![](ObjectExplorer.png)
@@ -90,57 +92,7 @@ I've also added some other functionality, like if one of the property values in 
 
 I also renamed this tool to Object Explorer (not to be confused with Tamar's Object Inspector).
 
-## Releases
-
-### 2022-11-23, Version 3.3.6
-
-* Double click now works on any column in the grid to edit property values.  
-* Right-click on grid row brings up context menu to edit property (same as double-click) or to toggle whether the property is a favorite
-* New checkbox for whether favorites are highlighted (with yellow highlighter)
-
-### 2022-05-22, Version 3.3.3
-
-* Add a TRY in TreeContainer.Init so no error if _Screen.oISXOptions.oKeyWordList doesn't exist
-
-### 2022-04-04
-
-* Updated the download zip file so it works with Thor Check for Updates.
-
-### 2022-04-03
-
-* Fixes a bug with an object based on Control in a running form and updates the displayed version number.
-
-### 2022-04-02
-
-* Fixes a bug with null nodes, such as with an object based on Empty or Control.
-
-### 2022-03-04
-
-* Automatically closes when the object being explored is released, and no longer prevents the object from being released
-
-### 2022-03-03
-
-* Changed hard-coded "explorer.vcx" in NEWOBJECT() statements to This.ClassLibrary so pathing isn't an issue.
-
-* Set AllowOutput to .F. in forms.
-
-* Ensure the explorer form is visible by being positioned within _screen or the active form, depending on the setting of ShowWindow.
-
-* Added support for Thor Check For Updates.
-
-### 2022-02-28
-
-* Initial release: Jim and Matt's original version plus the following changes by Doug Hennig:
-
-    * TreeContainer.NewNode: accept toParentNode and use the appropriate version of Nodes.Add if it's an object. This change (and the next one) prevents cashing for some objects (the TreeView was getting cranky when changing the Parent property of a node).
-
-    * TreeContainer.LoadObject and LoadOtherObject: call NewNode rather than using their own Nodes.Add calls.
-
-    * TreeContainer.NavigateToObject: specifically set loNode.Expanded to .T. because calling Expand doesn't necessary do that, also call loNode.EnsureVisible to ensure the TreeView is scrolled to the node. This fixes an issue with not automatically selecting the correct object in the TreeView at startup: the form was selected rather than the object, although the grid showed the properties for the correct object.
-
-    * TreeContainer.InputBox: use InputBox_ShowWindow1 if the form is in a top-level form, not if it's modal. This change (and the next one) allows Object Explorer to be used in apps with _screen.Visible set to .F. and using top-level forms.
-
-    * InputBox_ShowWindow1: set Desktop to .T. This doesn't affect apps with _screen.Visible =  .T. but does allow it to work when it's .F.
+[Change Log](Change%20Log.md)
 
 ----
 ## Contribution

--- a/ThorUpdater/CreateThorUpdate.ps1
+++ b/ThorUpdater/CreateThorUpdate.ps1
@@ -10,6 +10,14 @@ $excludeFiles = $exclude.Split(',')
 $exclude = $appInfo[4].Substring($appInfo[4].IndexOf('=') + 1).Trim()
 $excludeFolders = $exclude.Split(',')
 
+# -------------------------------------------------
+# JRN 2022-12-11 Create the Version.txt from pieces
+$VersionFile = 'Version.txt'
+cat VersionHeader.txt  >  $VersionFile
+cat '..\Change Log.md' >> $VersionFile
+cat VersionFooter.txt  >> $VersionFile
+# -------------------------------------------------
+
 # Get the name of the zip file.
 $zipFileName = "ThorUpdater\$appID.zip"
 

--- a/ThorUpdater/VersionFooter.txt
+++ b/ThorUpdater/VersionFooter.txt
@@ -1,0 +1,6 @@
+
+EndText
+
+Return lcNote
+
+EndProc 

--- a/ThorUpdater/VersionHeader.txt
+++ b/ThorUpdater/VersionHeader.txt
@@ -1,0 +1,12 @@
+lparameters toUpdateObject
+local ldDate
+ldDate = date()
+toUpdateObject.AvailableVersion = 'APPNAME-MAJORVERSION-update-' + dtoc(ldDate, 1)
+AddProperty(toUpdateObject, 'Notes', GetReleaseNotes())
+
+return toUpdateObject
+
+
+Procedure GetReleaseNotes
+
+Text to lcNote NoShow


### PR DESCRIPTION
Two changes re Change Log:

1. Change Log moved to separate page, with links at the top and also bottom of the current home page.
2. With a new update, file 'Version.txt' is rebuild from scratch so that it includes the change log, visible in Thor CFU.  Note that I am not able to completely test this, and it is embedded in the process of creating a new version and will probably need to wait until we have a new update.